### PR TITLE
feat: optional config

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -139,7 +139,7 @@ dynamicPlugins:
 orchestrator:
   sonataFlowService:
     baseUrl: http://localhost
-    port: 8899
+    port: 8080
     autoStart: true
     workflowsSource:
       gitRepositoryUrl: https://github.com/tiagodolphine/backstage-orchestrator-workflows

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -57,6 +57,10 @@ export class SonataFlowService {
     this.connection = this.extractConnectionConfig(config);
   }
 
+  public get autoStart(): boolean {
+    return this.connection.autoStart;
+  }
+
   public get url(): string {
     return `${this.connection.host}:${this.connection.port}`;
   }
@@ -366,9 +370,10 @@ export class SonataFlowService {
     const host = config.getString('orchestrator.sonataFlowService.baseUrl');
     const port = config.getNumber('orchestrator.sonataFlowService.port');
 
-    const resourcesPath = config.getString(
-      'orchestrator.sonataFlowService.workflowsSource.localPath',
-    );
+    const resourcesPath =
+      config.getOptionalString(
+        'orchestrator.sonataFlowService.workflowsSource.localPath',
+      ) ?? '';
 
     const containerImage =
       config.getOptionalString('orchestrator.sonataFlowService.container') ??

--- a/plugins/orchestrator-backend/src/service/WorkflowService.ts
+++ b/plugins/orchestrator-backend/src/service/WorkflowService.ts
@@ -42,9 +42,10 @@ export class WorkflowService {
     this.sonataFlowService = sonataFlowService;
     this.logger = logger;
     this.githubService = new GitService(logger, config);
-    this.repoURL = config.getString(
-      'orchestrator.sonataFlowService.workflowsSource.gitRepositoryUrl',
-    );
+    this.repoURL =
+      config.getOptionalString(
+        'orchestrator.sonataFlowService.workflowsSource.gitRepositoryUrl',
+      ) ?? '';
     this.autoPush =
       config.getOptionalBoolean(
         'orchestrator.sonataFlowService.workflowsSource.autoPush',

--- a/plugins/orchestrator-common/config.d.ts
+++ b/plugins/orchestrator-common/config.d.ts
@@ -23,7 +23,7 @@ export interface Config {
       /**
        * Workflows definitions source configurations
        */
-      workflowsSource:
+      workflowsSource?:
         | {
             /**
              * Remote git repository where workflows definitions are stored

--- a/plugins/orchestrator/README.md
+++ b/plugins/orchestrator/README.md
@@ -65,11 +65,14 @@ orchestrator:
   sonataFlowService:
     baseUrl: http://localhost
     port: 8899
+    autoStart: true
     workflowsSource:
       gitRepositoryUrl: https://github.com/tiagodolphine/backstage-orchestrator-workflows
       localPath: /tmp/orchestrator/repository
       autoPush: true
 ```
+
+when interacting with an existing Sonataflow backend service from `baseUrl` and `port`, `autoStart` needs to be unset or set to `false`, also the section of `workflowSource` can be neglect.
 
 For more information about the configuration options, including other optional properties, see the [config.d.ts](../orchestrator-common/config.d.ts) file.
 


### PR DESCRIPTION
[FLPATH 653 optional config](https://issues.redhat.com/browse/FLPATH-653)
As a user I'd like not to provide all settings under workflowsSource in orchestrator config as there are not in used in the dev mode when using a separate sonataflow instance (autostart=false).
```
orchestrator:  
 sonataFlowService:    
  baseUrl: http://127.0.0.1    
  port: 8080    
  autoStart: false    
  workflowsSource:      
    gitRepositoryUrl: https://github.com/abc/backstage-orchestrator-workflows      
    localPath: /tmp/orchestrator/repository      
    autoPush: false
```