### PR TITLE
fix: add dependency to plugin for backstage/backend-app-api

### DIFF
--- a/plugins/orchestrator-backend/dist-dynamic/package.json
+++ b/plugins/orchestrator-backend/dist-dynamic/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@octokit/rest": "^19.0.3",
     "@severlessworkflow/sdk-typescript": "^3.0.3",
+    "@urql/core": "^4.1.4",
     "cloudevents": "^8.0.0",
     "express": "^4.18.2",
     "express-promise-router": "^4.1.1",
@@ -61,12 +62,12 @@
     "openapi-types": "^12.1.3",
     "winston": "^3.11.0",
     "yn": "^5.0.0",
-    "@urql/core": "^4.1.4",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {},
   "bundleDependencies": true,
   "peerDependencies": {
+    "@backstage/backend-app-api": "^0.5.8",
     "@backstage/backend-common": "^0.19.8",
     "@backstage/backend-plugin-api": "^0.6.6",
     "@backstage/backend-plugin-manager": "npm:@janus-idp/backend-plugin-manager@0.0.2-janus.5",


### PR DESCRIPTION
Adding a missing piece from https://github.com/caponetto/backstage-plugins/pull/27