### PR TITLE
feat: introduced the workflows/overview endpoint

### DIFF
--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -247,8 +247,8 @@ export class SonataFlowService {
                 this.logger.error(`Error when fetching instances: ${error}`);
               }
 
-              // eslint-disable-next-line no-loop-func
-              processInstances.forEach((pInstance: ProcessInstance) => {
+              for (let i = 0; i < processInstances.length; i++) {
+                const pInstance: ProcessInstance = processInstances[i];
                 if (new Date(pInstance.start) > lastTriggered) {
                   lastTriggered = new Date(pInstance.start);
                   lastRunStatus = pInstance.state;
@@ -259,7 +259,7 @@ export class SonataFlowService {
                   totalDuration += end.valueOf() - start.valueOf();
                   counter++;
                 }
-              });
+              }
               offset += limit;
             } while (processInstances.length > 0);
 

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -249,7 +249,7 @@ export class SonataFlowService {
               lastTriggered: lastTriggered,
               lastRunStatus: lastRunStatus,
               type: this.extractWorkflowType(definition),
-              avgDurationMs: counter == 0 ? 0 : totalDuration / counter,
+              avgDurationMs: counter ? totalDuration / counter : 0,
               documentation: definition.description,
             };
             return result;

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -523,6 +523,7 @@ export class SonataFlowService {
     return {
       workflowId: definition.id,
       name: definition.name,
+      uri: await this.fetchWorkflowUri(workflowId),
       lastTriggeredMs: lastTriggered.getTime(),
       lastRunStatus:
         lastRunStatus.length > 0

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -399,9 +399,12 @@ export class SonataFlowService {
 
   private extractWorkflowType(workflowDef: WorkflowDefinition): string {
     if (workflowDef.annotations) {
-      const firstValue: string = workflowDef.annotations[0];
-      const value: string = firstValue.substring(firstValue.indexOf('/') + 1);
-      return value[0].toUpperCase() + value.slice(1);
+      for (const annotation of workflowDef.annotations) {
+        if (annotation.includes('workflow-type/')) {
+          const value: string = annotation.split('/')[1].trim();
+          return value.charAt(0).toUpperCase() + value.slice(1);
+        }
+      }
     }
 
     return '';

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -228,7 +228,7 @@ export class SonataFlowService {
             let totalDuration = 0;
 
             do {
-              const graphQlQuery = `{ ProcessInstances(where: {processId: {equal: "${definition.id}" } }, pagination: {limit: "${limit}", offset: "${offset}"}) { processName, state, start, lastUpdate, end } }`;
+              const graphQlQuery = `{ ProcessInstances(where: {processId: {equal: "${definition.id}" } }, pagination: {limit: ${limit}, offset: ${offset}}) { processName, state, start, lastUpdate, end } }`;
 
               try {
                 const graphQlResponse = await executeWithRetry(() =>
@@ -265,8 +265,15 @@ export class SonataFlowService {
             const result: WorkflowOverview = {
               workflowId: definition.id,
               name: definition.name,
-              lastTriggered: lastTriggered === new Date(0) ? '' : lastTriggered,
-              lastRunStatus: lastRunStatus,
+              lastTriggered:
+                lastTriggered === new Date(0)
+                  ? ''
+                  : parseInt((lastTriggered.getTime() / 1000).toFixed(0), 10),
+              lastRunStatus:
+                lastRunStatus.length > 0
+                  ? lastRunStatus.charAt(0).toUpperCase() +
+                    lastRunStatus.slice(1).toLowerCase()
+                  : '',
               type: this.extractWorkflowType(definition),
               avgDurationMs: counter ? totalDuration / counter : 0,
               description: definition.description,

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -531,7 +531,7 @@ export class SonataFlowService {
             lastRunStatus.slice(1).toLowerCase()
           : undefined,
       type: this.extractWorkflowType(definition),
-      avgDurationMs: counter ? totalDuration / counter : 0,
+      avgDurationMs: counter ? totalDuration / counter : undefined,
       description: definition.description,
     };
   }

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -263,6 +263,7 @@ export class SonataFlowService {
             } while (processInstances.length > 0);
 
             const result: WorkflowOverview = {
+              workflowId: definition.id,
               name: definition.name,
               lastTriggered: lastTriggered === new Date(0) ? '' : lastTriggered,
               lastRunStatus: lastRunStatus,

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -96,6 +96,10 @@ export class SonataFlowService {
         const json = (await response.json()) as SonataFlowSource[];
         // Assuming only one source in the list
         return json.pop()?.uri;
+      } else {
+        this.logger.error(
+          `Response was NOT okay when fetch(${this.url}/management/processes/${workflowId}/sources). Received response: ${response}`,
+        );
       }
     } catch (error) {
       this.logger.error(`Error when fetching workflow uri: ${error}`);
@@ -114,6 +118,10 @@ export class SonataFlowService {
 
       if (response.ok) {
         return await response.text();
+      } else {
+        this.logger.error(
+          `Response was NOT okay when fetch(${this.url}/management/processes/${workflowId}/source). Received response: ${response}`,
+        );
       }
     } catch (error) {
       this.logger.error(`Error when fetching workflow source: ${error}`);
@@ -142,6 +150,10 @@ export class SonataFlowService {
       );
       if (response.ok) {
         return await response.json();
+      } else {
+        this.logger.error(
+          `Response was NOT okay when fetch(${this.url}/q/openapi.json). Received response: ${response}`,
+        );
       }
     } catch (error) {
       this.logger.error(`Error when fetching openapi: ${error}`);
@@ -180,6 +192,10 @@ export class SonataFlowService {
           }),
         );
         return items.filter((item): item is WorkflowItem => !!item);
+      } else {
+        this.logger.error(
+          `Response was NOT okay when fetch(${this.url}/management/processes). Received response: ${response}`,
+        );
       }
     } catch (error) {
       this.logger.error(`Error when fetching workflows: ${error}`);
@@ -256,6 +272,10 @@ export class SonataFlowService {
           }),
         );
         return items.filter((item): item is WorkflowOverview => !!item);
+      } else {
+        this.logger.error(
+          `Response was NOT okay when fetch(${this.url}/management/processes). Received response: ${response}`,
+        );
       }
     } catch (error) {
       this.logger.error(

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -520,16 +520,10 @@ export class SonataFlowService {
       offset += limit;
     } while (processInstances.length > 0);
 
-    const result: WorkflowOverview = {
+    return {
       workflowId: definition.id,
       name: definition.name,
-      lastTriggered:
-        lastTriggered === new Date(0)
-          ? undefined
-          : parseInt(
-              (lastTriggered.getTime() / 1000).toFixed(0),
-              10,
-            ).toString(),
+      lastTriggeredMs: lastTriggered.getTime(),
       lastRunStatus:
         lastRunStatus.length > 0
           ? lastRunStatus.charAt(0).toUpperCase() +
@@ -539,6 +533,5 @@ export class SonataFlowService {
       avgDurationMs: counter ? totalDuration / counter : 0,
       description: definition.description,
     };
-    return result;
   }
 }

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -268,7 +268,7 @@ export class SonataFlowService {
               name: definition.name,
               lastTriggered:
                 lastTriggered === new Date(0)
-                  ? ''
+                  ? undefined
                   : parseInt(
                       (lastTriggered.getTime() / 1000).toFixed(0),
                       10,
@@ -277,7 +277,7 @@ export class SonataFlowService {
                 lastRunStatus.length > 0
                   ? lastRunStatus.charAt(0).toUpperCase() +
                     lastRunStatus.slice(1).toLowerCase()
-                  : '',
+                  : undefined,
               type: this.extractWorkflowType(definition),
               avgDurationMs: counter ? totalDuration / counter : 0,
               description: definition.description,
@@ -431,7 +431,9 @@ export class SonataFlowService {
     return false;
   }
 
-  private extractWorkflowType(workflowDef: WorkflowDefinition): string {
+  private extractWorkflowType(
+    workflowDef: WorkflowDefinition,
+  ): string | undefined {
     if (workflowDef.annotations) {
       for (const annotation of workflowDef.annotations) {
         if (annotation.includes('workflow-type/')) {
@@ -441,7 +443,7 @@ export class SonataFlowService {
       }
     }
 
-    return '';
+    return undefined;
   }
 
   private createLauncherCommand(): LauncherCommand {

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -269,7 +269,10 @@ export class SonataFlowService {
               lastTriggered:
                 lastTriggered === new Date(0)
                   ? ''
-                  : parseInt((lastTriggered.getTime() / 1000).toFixed(0), 10),
+                  : parseInt(
+                      (lastTriggered.getTime() / 1000).toFixed(0),
+                      10,
+                    ).toString(),
               lastRunStatus:
                 lastRunStatus.length > 0
                   ? lastRunStatus.charAt(0).toUpperCase() +

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -269,7 +269,7 @@ export class SonataFlowService {
               lastRunStatus: lastRunStatus,
               type: this.extractWorkflowType(definition),
               avgDurationMs: counter ? totalDuration / counter : 0,
-              documentation: definition.description,
+              description: definition.description,
             };
             return result;
           }),

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -96,11 +96,10 @@ export class SonataFlowService {
         const json = (await response.json()) as SonataFlowSource[];
         // Assuming only one source in the list
         return json.pop()?.uri;
-      } else {
-        this.logger.error(
-          `Response was NOT okay when fetch(${this.url}/management/processes/${workflowId}/sources). Received response: ${response}`,
-        );
       }
+      this.logger.error(
+        `Response was NOT okay when fetch(${this.url}/management/processes/${workflowId}/sources). Received response: ${response}`,
+      );
     } catch (error) {
       this.logger.error(`Error when fetching workflow uri: ${error}`);
     }
@@ -118,11 +117,10 @@ export class SonataFlowService {
 
       if (response.ok) {
         return await response.text();
-      } else {
-        this.logger.error(
-          `Response was NOT okay when fetch(${this.url}/management/processes/${workflowId}/source). Received response: ${response}`,
-        );
       }
+      this.logger.error(
+        `Response was NOT okay when fetch(${this.url}/management/processes/${workflowId}/source). Received response: ${response}`,
+      );
     } catch (error) {
       this.logger.error(`Error when fetching workflow source: ${error}`);
     }
@@ -150,11 +148,10 @@ export class SonataFlowService {
       );
       if (response.ok) {
         return await response.json();
-      } else {
-        this.logger.error(
-          `Response was NOT okay when fetch(${this.url}/q/openapi.json). Received response: ${response}`,
-        );
       }
+      this.logger.error(
+        `Response was NOT okay when fetch(${this.url}/q/openapi.json). Received response: ${response}`,
+      );
     } catch (error) {
       this.logger.error(`Error when fetching openapi: ${error}`);
     }
@@ -192,11 +189,10 @@ export class SonataFlowService {
           }),
         );
         return items.filter((item): item is WorkflowItem => !!item);
-      } else {
-        this.logger.error(
-          `Response was NOT okay when fetch(${this.url}/management/processes). Received response: ${response}`,
-        );
       }
+      this.logger.error(
+        `Response was NOT okay when fetch(${this.url}/management/processes). Received response: ${response}`,
+      );
     } catch (error) {
       this.logger.error(`Error when fetching workflows: ${error}`);
     }
@@ -272,11 +268,10 @@ export class SonataFlowService {
           }),
         );
         return items.filter((item): item is WorkflowOverview => !!item);
-      } else {
-        this.logger.error(
-          `Response was NOT okay when fetch(${this.url}/management/processes). Received response: ${response}`,
-        );
       }
+      this.logger.error(
+        `Response was NOT okay when fetch(${this.url}/management/processes). Received response: ${response}`,
+      );
     } catch (error) {
       this.logger.error(
         `Error when fetching workflows for workflowoverview: ${error}`,

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -247,6 +247,7 @@ export class SonataFlowService {
                 this.logger.error(`Error when fetching instances: ${error}`);
               }
 
+              // eslint-disable-next-line no-loop-func
               processInstances.forEach((pInstance: ProcessInstance) => {
                 if (new Date(pInstance.start) > lastTriggered) {
                   lastTriggered = new Date(pInstance.start);

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -222,7 +222,7 @@ export class SonataFlowService {
             const graphQlQuery = `{ ProcessInstances(where: {processId: {equal: "${definition.id}" } } ) { processName, state, start, lastUpdate, end } }`;
             let processInstances: ProcessInstance[] = [];
             try {
-              const response = await executeWithRetry(() =>
+              const graphQlResponse = await executeWithRetry(() =>
                 fetch(`${this.url}/graphql`, {
                   method: 'POST',
                   body: JSON.stringify({ query: graphQlQuery }),
@@ -230,8 +230,8 @@ export class SonataFlowService {
                 }),
               );
 
-              if (response.ok) {
-                const json = await response.json();
+              if (graphQlResponse.ok) {
+                const json = await graphQlResponse.json();
                 processInstances = json.data.ProcessInstances;
               }
             } catch (error) {

--- a/plugins/orchestrator-backend/src/service/SonataFlowService.ts
+++ b/plugins/orchestrator-backend/src/service/SonataFlowService.ts
@@ -244,14 +244,15 @@ export class SonataFlowService {
               }
             });
 
-            return {
+            const result: WorkflowOverview = {
               name: definition.name,
               lastTriggered: lastTriggered,
               lastRunStatus: lastRunStatus,
               type: this.extractWorkflowType(definition),
               avgDurationMs: counter == 0 ? 0 : totalDuration / counter,
               documentation: definition.description,
-            } as WorkflowOverview;
+            };
+            return result;
           }),
         );
         return items.filter((item): item is WorkflowOverview => !!item);

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -15,6 +15,7 @@ import {
   WorkflowDataInputSchemaResponse,
   WorkflowItem,
   WorkflowListResult,
+  WorkflowOverviewListResult,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
 import { RouterArgs } from '../routerWrapper';
@@ -130,6 +131,23 @@ function setupInternalRoutes(
   router.get('/workflows/definitions', async (_, response) => {
     const swfs = await DataIndexService.getWorkflowDefinitions();
     response.json(ApiResponseBuilder.SUCCESS_RESPONSE(swfs));
+  });
+
+  router.get('/workflows/overview', async (_, res) => {
+    const overviews = await sonataFlowService.fetchWorkflowOverviews();
+
+    if (!overviews) {
+      res.status(500).send("Couldn't fetch workflow overviews");
+      return;
+    }
+
+    const result: WorkflowOverviewListResult = {
+      items: overviews,
+      limit: 0,
+      offset: 0,
+      totalCount: overviews?.length ?? 0,
+    };
+    res.status(200).json(result);
   });
 
   router.get('/workflows', async (_, res) => {

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -74,10 +74,10 @@ export enum WorkflowCategory {
 }
 
 export interface WorkflowOverview {
-  name: string;
+  name?: string;
   lastTriggered: Date;
   lastRunStatus: string;
   type: string;
   avgDurationMs: number;
-  documentation: string;
+  documentation?: string;
 }

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -32,6 +32,13 @@ export type WorkflowListResult = {
   limit: number;
 };
 
+export type WorkflowOverviewListResult = {
+  items: WorkflowOverview[];
+  totalCount: number;
+  offset: number;
+  limit: number;
+};
+
 export type WorkflowFormat = 'yaml' | 'json';
 
 export interface WorkflowSample {
@@ -64,4 +71,13 @@ export interface WorkflowExecutionResponse {
 export enum WorkflowCategory {
   ASSESSMENT = 'assessment',
   INFRASTRUCTURE = 'infrastructure',
+}
+
+export interface WorkflowOverview {
+  name: string;
+  lastTriggered: Date;
+  lastRunStatus: string;
+  type: string;
+  avgDurationMs: number;
+  documentation: string;
 }

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -80,6 +80,6 @@ export interface WorkflowOverview {
   lastTriggeredMs?: number;
   lastRunStatus?: string;
   type?: string;
-  avgDurationMs: number;
+  avgDurationMs?: number;
   description?: string;
 }

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -76,7 +76,7 @@ export enum WorkflowCategory {
 export interface WorkflowOverview {
   workflowId: string;
   name?: string;
-  lastTriggered: string | Date;
+  lastTriggered: string | number;
   lastRunStatus: string;
   type: string;
   avgDurationMs: number;

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -80,5 +80,5 @@ export interface WorkflowOverview {
   lastRunStatus: string;
   type: string;
   avgDurationMs: number;
-  documentation?: string;
+  description?: string;
 }

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -77,8 +77,8 @@ export interface WorkflowOverview {
   workflowId: string;
   name?: string;
   lastTriggered?: string;
-  lastRunStatus: string;
-  type: string;
+  lastRunStatus?: string;
+  type?: string;
   avgDurationMs: number;
   description?: string;
 }

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -76,7 +76,7 @@ export enum WorkflowCategory {
 export interface WorkflowOverview {
   workflowId: string;
   name?: string;
-  lastTriggered: string | number;
+  lastTriggered?: string;
   lastRunStatus: string;
   type: string;
   avgDurationMs: number;

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -76,7 +76,7 @@ export enum WorkflowCategory {
 export interface WorkflowOverview {
   workflowId: string;
   name?: string;
-  lastTriggered?: string;
+  lastTriggeredMs?: number;
   lastRunStatus?: string;
   type?: string;
   avgDurationMs: number;

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -74,6 +74,7 @@ export enum WorkflowCategory {
 }
 
 export interface WorkflowOverview {
+  workflowId: string;
   name?: string;
   lastTriggered: string | Date;
   lastRunStatus: string;

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -76,6 +76,7 @@ export enum WorkflowCategory {
 export interface WorkflowOverview {
   workflowId: string;
   name?: string;
+  uri?: string;
   lastTriggeredMs?: number;
   lastRunStatus?: string;
   type?: string;

--- a/plugins/orchestrator-common/src/types.ts
+++ b/plugins/orchestrator-common/src/types.ts
@@ -75,7 +75,7 @@ export enum WorkflowCategory {
 
 export interface WorkflowOverview {
   name?: string;
-  lastTriggered: Date;
+  lastTriggered: string | Date;
   lastRunStatus: string;
   type: string;
   avgDurationMs: number;


### PR DESCRIPTION
Created this PR based on previous PR (https://github.com/caponetto/backstage-plugins/pull/26) because of rebase in the target branch.

Expected API response: `GET http://localhost:7007/api/orchestrator/workflows/overview`

    {
        "items": [
            {
                "workflowId": "yamlgreet",
                "name": "Greeting workflow",
                "lastTriggered": 1701083292,
                "lastRunStatus": "Completed",
                "type": "Assessment",
                "avgDurationMs": 12,
                "description": "YAML based greeting workflow"
            }
        ],
        "limit": 0,
        "offset": 0,
        "totalCount": 1
    }