### PR TITLE
chore(orchestrator): implement the WorkflowViewerFormatter

### DIFF
--- a/plugins/orchestrator/src/dataFormatters/DataFormatter.ts
+++ b/plugins/orchestrator/src/dataFormatters/DataFormatter.ts
@@ -1,5 +1,5 @@
 interface DataFormatter<Data, FormattedData> {
-  format(Data): FormattedData;
+  format(data: Data): FormattedData;
 }
 
 export default DataFormatter;

--- a/plugins/orchestrator/src/dataFormatters/DataFormatter.ts
+++ b/plugins/orchestrator/src/dataFormatters/DataFormatter.ts
@@ -1,0 +1,5 @@
+interface DataFormatter<Data, FormattedData> {
+  format(Data): FormattedData;
+}
+
+export default DataFormatter;

--- a/plugins/orchestrator/src/dataFormatters/DataFormatterInterface.ts
+++ b/plugins/orchestrator/src/dataFormatters/DataFormatterInterface.ts
@@ -1,5 +1,0 @@
-interface DataFormatterInterface<Data, FormattedData> {
-  format(Data): FormattedData;
-}
-
-export default DataFormatterInterface;

--- a/plugins/orchestrator/src/dataFormatters/DataFormatterInterface.ts
+++ b/plugins/orchestrator/src/dataFormatters/DataFormatterInterface.ts
@@ -1,0 +1,5 @@
+interface DataFormatterInterface<Data, FormattedData> {
+  format(Data): FormattedData;
+}
+
+export default DataFormatterInterface;

--- a/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
+++ b/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.test.ts
@@ -1,0 +1,51 @@
+import { WorkflowOverview } from '@janus-idp/backstage-plugin-orchestrator-common';
+
+import WorkflowOverviewFormatter, {
+  FormattedWorkflowOverview,
+} from './WorkflowOverviewFormatter';
+
+describe('WorkflowOverviewAdapter', () => {
+  it('should adapt WorkflowOverview to AdaptedWorkflowOverview', () => {
+    // Mock data for testing
+    const mockWorkflowOverview: WorkflowOverview = {
+      workflowId: '123',
+      name: 'Sample Workflow',
+      lastTriggeredMs: 1697276096000,
+      lastRunStatus: 'Success',
+      type: 'Sample Type',
+      avgDurationMs: 150000,
+      description: 'Sample description',
+      uri: 'sample.workflow.sw.yaml',
+    };
+
+    const adaptedData: FormattedWorkflowOverview =
+      WorkflowOverviewFormatter.format(mockWorkflowOverview);
+
+    expect(adaptedData.id).toBe(mockWorkflowOverview.workflowId);
+    expect(adaptedData.name).toBe(mockWorkflowOverview.name);
+    expect(adaptedData.lastTriggered).toBe('14/10/23 09:34:56');
+    expect(adaptedData.lastRunStatus).toBe(mockWorkflowOverview.lastRunStatus);
+    expect(adaptedData.type).toBe(mockWorkflowOverview.type);
+    expect(adaptedData.avgDuration).toBe('2 min');
+    expect(adaptedData.description).toBe(mockWorkflowOverview.description);
+    expect(adaptedData.format).toBe('yaml'); // Adjust based on your expected value
+  });
+
+  it('should have --- for undefined data', () => {
+    // Mock data for testing
+    const mockWorkflowOverview: WorkflowOverview = {
+      workflowId: '123',
+    };
+    const adaptedData: FormattedWorkflowOverview =
+      WorkflowOverviewFormatter.format(mockWorkflowOverview);
+
+    expect(adaptedData.id).toBe(mockWorkflowOverview.workflowId);
+    expect(adaptedData.name).toBe('---');
+    expect(adaptedData.lastTriggered).toBe('---');
+    expect(adaptedData.lastRunStatus).toBe('---');
+    expect(adaptedData.type).toBe('---');
+    expect(adaptedData.avgDuration).toBe('---');
+    expect(adaptedData.description).toBe('---');
+    expect(adaptedData.format).toBe('yaml');
+  });
+});

--- a/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
+++ b/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
@@ -1,0 +1,72 @@
+import moment from 'moment';
+
+import {
+  extractWorkflowFormatFromUri,
+  WorkflowFormat,
+  WorkflowOverview,
+} from '@janus-idp/backstage-plugin-orchestrator-common';
+
+import DataFormatterInterface from './DataFormatterInterface';
+
+const UNAVAILABLE = '---';
+
+export interface FormattedWorkflowOverview {
+  id: string;
+  name: string;
+  lastTriggered: string;
+  lastRunStatus: string;
+  type: string;
+  avgDuration: string;
+  description: string;
+  format: WorkflowFormat;
+}
+
+export interface FormattedWorkflowOverview {}
+
+const formatDuration = (milliseconds: number): string => {
+  let sec = Math.round(milliseconds / 1000);
+  let min = 0;
+  let hr = 0;
+  if (sec >= 60) {
+    min = Math.floor(sec / 60);
+    sec %= 60;
+  }
+  if (min >= 60) {
+    hr = Math.floor(min / 60);
+    min %= 60;
+  }
+  if (hr > 0) {
+    return `${hr} h`;
+  }
+  if (min > 0) {
+    return `${min} min`;
+  }
+  if (sec > 0) {
+    return `${sec} sec`;
+  }
+  return 'less than a sec';
+};
+
+const WorkflowOverviewFormatter: DataFormatterInterface<
+  WorkflowOverview,
+  FormattedWorkflowOverview
+> = {
+  format: (data: WorkflowOverview): FormattedWorkflowOverview => {
+    return {
+      id: data.workflowId,
+      name: data.name || UNAVAILABLE,
+      lastTriggered: data.lastTriggeredMs
+        ? moment(data.lastTriggeredMs).format('DD/MM/YY HH:mm:ss')
+        : UNAVAILABLE,
+      lastRunStatus: data.lastRunStatus || UNAVAILABLE,
+      type: data.type || UNAVAILABLE,
+      avgDuration: data.avgDurationMs
+        ? formatDuration(data.avgDurationMs)
+        : UNAVAILABLE,
+      description: data.description || UNAVAILABLE,
+      format: data.uri ? extractWorkflowFormatFromUri(data.uri) : 'yaml',
+    };
+  },
+};
+
+export default WorkflowOverviewFormatter;

--- a/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
+++ b/plugins/orchestrator/src/dataFormatters/WorkflowOverviewFormatter.ts
@@ -6,7 +6,7 @@ import {
   WorkflowOverview,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
-import DataFormatterInterface from './DataFormatterInterface';
+import DataFormatter from './DataFormatter';
 
 const UNAVAILABLE = '---';
 
@@ -20,8 +20,6 @@ export interface FormattedWorkflowOverview {
   description: string;
   format: WorkflowFormat;
 }
-
-export interface FormattedWorkflowOverview {}
 
 const formatDuration = (milliseconds: number): string => {
   let sec = Math.round(milliseconds / 1000);
@@ -47,7 +45,7 @@ const formatDuration = (milliseconds: number): string => {
   return 'less than a sec';
 };
 
-const WorkflowOverviewFormatter: DataFormatterInterface<
+const WorkflowOverviewFormatter: DataFormatter<
   WorkflowOverview,
   FormattedWorkflowOverview
 > = {


### PR DESCRIPTION
implement the WorkflowViewerFormatter - a utility for converting the WorkflowViewer backend data to data the components can consume
includes a generic Formatter interface for reuse