### PR TITLE
feat(orchestrator): use assessment process id as bk for next workflows

### DIFF
--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -15,9 +15,7 @@ import validator from '@rjsf/validator-ajv8';
 import { JSONSchema7 } from 'json-schema';
 
 import {
-  getWorkflowCategory,
   WORKFLOW_TITLE,
-  WorkflowCategory,
   WorkflowDataInputSchemaResponse,
 } from '@janus-idp/backstage-plugin-orchestrator-common';
 
@@ -78,14 +76,7 @@ export const ExecuteWorkflowPage = (props: ExecuteWorkflowPageProps) => {
     }
 
     setLoading(true);
-    const workflowCategory = getWorkflowCategory(
-      schemaResponse?.workflowItem.definition,
-    );
-    if (workflowCategory === WorkflowCategory.ASSESSMENT) {
-      Object.assign(parameters, { businessKey: crypto.randomUUID() });
-    } else {
-      Object.assign(parameters, { businessKey: businessKey ?? '' });
-    }
+    Object.assign(parameters, { businessKey: businessKey ?? '' });
     const response = await orchestratorApi.executeWorkflow({
       workflowId,
       parameters,

--- a/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
+++ b/plugins/orchestrator/src/components/ExecuteWorkflowPage/ExecuteWorkflowPage.tsx
@@ -76,7 +76,9 @@ export const ExecuteWorkflowPage = (props: ExecuteWorkflowPageProps) => {
     }
 
     setLoading(true);
-    Object.assign(parameters, { businessKey: businessKey ?? '' });
+    if (businessKey !== undefined) {
+      Object.assign(parameters, { businessKey: businessKey });
+    }
     const response = await orchestratorApi.executeWorkflow({
       workflowId,
       parameters,

--- a/plugins/orchestrator/src/components/WorkflownstancesViewerPage/AssessmentResultViewer.tsx
+++ b/plugins/orchestrator/src/components/WorkflownstancesViewerPage/AssessmentResultViewer.tsx
@@ -62,7 +62,7 @@ export const AssessmentResultViewer = (props: AssessmentResultViewerProps) => {
           <Link
             href={executeWorkflowLink({
               workflowId: workflowOption.id,
-              businessKey: selectedInstance?.businessKey ?? '',
+              businessKey: selectedInstance?.id ?? '',
             })}
           >
             {workflowOption.name}
@@ -79,7 +79,7 @@ export const AssessmentResultViewer = (props: AssessmentResultViewerProps) => {
           <Link
             href={executeWorkflowLink({
               workflowId: workflowOption.id,
-              businessKey: selectedInstance?.businessKey ?? '',
+              businessKey: selectedInstance?.id ?? '',
             })}
           >
             {workflowOption.name}

--- a/plugins/orchestrator/src/components/WorkflownstancesViewerPage/ProcessInstancesTable.tsx
+++ b/plugins/orchestrator/src/components/WorkflownstancesViewerPage/ProcessInstancesTable.tsx
@@ -74,7 +74,7 @@ export const ProcessInstancesTable = (props: ProcessInstancesTableProps) => {
           return {
             pid: pi.id,
             name: pi.processId,
-            businessKey: pi.businessKey?.substring(0, 8),
+            businessKey: pi.businessKey?.substring(0, 8) ?? '-',
             state: pi.state,
           };
         })


### PR DESCRIPTION
This change removes random UUID generated to associate assessment and recommended workflows to use the assessment process id as business key (bk) for others. By doing so, the assessment won't longer have a bk.

<img width="1733" alt="Screenshot 2024-01-11 at 10 06 39 AM" src="https://github.com/caponetto/backstage-plugins/assets/15964569/f1a1646d-bc16-43d0-a96f-5afb68b80341">
