### PR TITLE
fix(orchestrator): disable catalog integration

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -138,7 +138,7 @@ dynamicPlugins:
 
 orchestrator:
   catalog:
-    isEnabled: true
+    isEnabled: false
   editor:
     path: /workflow-editor-envelope
   sonataFlowService:


### PR DESCRIPTION
since it's not possible to customize the backstage create page, it was agreed that integrating with the catalog by providing the workflows as template entities is not a viable option.